### PR TITLE
Fix cppruntime duplicated package name causes build error

### DIFF
--- a/lib/cppruntime/src/main/AndroidManifest.xml
+++ b/lib/cppruntime/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.webkit.androidjsc" />
+    package="org.webkit.androidjsc_cppruntime" />


### PR DESCRIPTION
Summary:
    Gradle will have a build error during generating APK if user depends
    both android-jsc and android-jsc-cppruntime.

    ```
    > Task :app:transformDexArchiveWithExternalLibsDexMergerForDebug FAILED
    D8: Program type already present: org.webkit.androidjsc.BuildConfig
    ```

    The reason is that gradle will generate BuildConfig from each libraries and
    there are two duplicated org.webkit.androidjsc.BuildConfig.

Test Plan:
    Pure RN 0.57 + JSC from this repo (build locally or from CircleCI).
    To test if gradle could generate APK successfully.