### PR TITLE
allow linking against custom 'libc++_shared.so'

### DIFF
--- a/scripts/compile/toolchain.sh
+++ b/scripts/compile/toolchain.sh
@@ -11,4 +11,4 @@ $ANDROID_NDK/build/tools/make_standalone_toolchain.py \
     --arch $ARCH \
     --stl libc++
 
-cp $TOOLCHAIN_LINK_DIR/libc++_shared.so $INSTALL_CPPRUNTIME_DIR
+cp ${PATH_TO_LIBCPLUSPLUSSHARED_BINARY:-$TOOLCHAIN_LINK_DIR/libc++_shared.so}  $INSTALL_CPPRUNTIME_DIR


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
We have a react native project with several native dependencies which depend on a specific version of `libc++_shared.so`. To prevent native mismatches we rebuilt jsc (thanks for this amazing repo!) and linked against our version of the library.

We thought it may make sense to have an api for this in the build scripts. This pr allows setting the env variable `PATH_TO_LIBCPLUSPLUSSHARED_BINARY` to point to a specific location of `libc++_shared.so`. I'm happy to hear what you guys think about the change!

```bash
PATH_TO_LIBCPLUSPLUSSHARED_BINARY="..." npm run start
```
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
- ci should be enough

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)