### PR TITLE
Upgrade ICU

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           name: install subversion
           command: |
             sudo apt-get update
-            sudo apt-get install coreutils realpath curl git subversion python-dev ruby gperf -y
+            sudo apt-get install coreutils realpath curl git subversion python-dev python3-dev ruby gperf -y
       - run:
           name: upgrade node
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,8 @@ jobs:
           name: install subversion
           command: |
             sudo apt-get update
-            sudo apt-get install coreutils realpath curl git subversion python-dev python3-dev ruby gperf -y
+            sudo apt-get install coreutils realpath curl git subversion python-dev ruby gperf -y
+            pyenv global 3.5.2
       - run:
           name: upgrade node
           command: |

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "config": {
     "webkitGTK": "2.24.2",
-    "chromiumICUCommit": "b34251f8b762f8e2112a89c587855ca4297fed96"
+    "chromiumICUCommit": "64e5d7d43a1ff205e3787ab6150bbc1a1837332b"
   }
 }

--- a/patches/icu.patch
+++ b/patches/icu.patch
@@ -2,19 +2,19 @@ diff -aur target-org/icu/source/config/Makefile.inc.in target/icu/source/config/
 --- target-org/icu/source/config/Makefile.inc.in	2017-07-05 13:23:06.000000000 +0200
 +++ target/icu/source/config/Makefile.inc.in	2017-07-06 14:02:52.275016858 +0200
 @@ -143,7 +143,7 @@
- 
+
  # Versioned target for a shared library
  FINAL_SO_TARGET = $(SO_TARGET).$(SO_TARGET_VERSION)
 -MIDDLE_SO_TARGET = $(SO_TARGET).$(SO_TARGET_VERSION_MAJOR)
 +MIDDLE_SO_TARGET = $(SO_TARGET)
- 
+
  # Access to important ICU tools.
- # Use as follows:  $(INVOKE) $(GENRB) arguments .. 
+ # Use as follows:  $(INVOKE) $(GENRB) arguments ..
 diff -aur target-org/icu/source/config/mh-linux target/icu/source/config/mh-linux
 --- target-org/icu/source/config/mh-linux	2017-07-05 13:23:06.000000000 +0200
 +++ target/icu/source/config/mh-linux	2017-07-06 14:02:52.275016858 +0200
 @@ -25,9 +25,12 @@
- 
+
  ## Compiler switch to embed a library name
  # The initial tab in the next line is to prevent icu-config from reading it.
 -	LD_SONAME = -Wl,-soname -Wl,$(notdir $(MIDDLE_SO_TARGET))
@@ -25,7 +25,7 @@ diff -aur target-org/icu/source/config/mh-linux target/icu/source/config/mh-linu
  #SH# # We can't depend on MIDDLE_SO_TARGET being set.
 -#SH# LD_SONAME=
 +#SH# LD_SONAME=${SO_TARGET}
- 
+
  ## Shared library options
  LD_SOOPTIONS= -Wl,-Bsymbolic
 diff -aur target-org/icu/source/data/Makefile.in target/icu/source/data/Makefile.in
@@ -41,22 +41,6 @@ diff -aur target-org/icu/source/data/Makefile.in target/icu/source/data/Makefile
 +#ifeq ($(PKGDATA_VERSIONING),)
 +#PKGDATA_VERSIONING = -r $(SO_TARGET_VERSION)
 +#endif
- 
+
  # This allows all the data to be in one directory
  ifeq ($(PKGDATA_MODE),dll)
-diff -aur target-org/icu/source/i18n/digitlst.cpp target/icu/source/i18n/digitlst.cpp
---- target-org/icu/source/i18n/digitlst.cpp	2018-07-23 11:20:13.000000000 +0200
-+++ target/icu/source/i18n/digitlst.cpp	2018-07-23 15:29:24.729402639 +0200
-@@ -61,11 +61,7 @@
- #endif
- 
- #if U_USE_STRTOD_L
--# if U_PLATFORM_USES_ONLY_WIN32_API || U_PLATFORM == U_PF_CYGWIN
--#   include <locale.h>
--# else
--#   include <xlocale.h>
--# endif
-+# include <xlocale.h>
- #endif
- 
- // ***************************************************************************

--- a/scripts/compile/icu.sh
+++ b/scripts/compile/icu.sh
@@ -25,6 +25,7 @@ else
     BUILD_TYPE_CONFIG="--enable-debug=yes"
 fi
 
+ICU_DATA_FILTER_FILE="${TARGETDIR}/icu/filters/android.json" \
 $TARGETDIR/icu/source/configure --prefix=$(pwd)/prebuilts \
     $BUILD_TYPE_CONFIG \
     --host=$CROSS_COMPILE_PLATFORM \
@@ -35,7 +36,6 @@ $TARGETDIR/icu/source/configure --prefix=$(pwd)/prebuilts \
     --enable-icuio=no \
     --enable-layout=no \
     --enable-layoutex=no \
-    --enable-tools=no \
     --enable-tests=no \
     --enable-samples=no \
     --enable-dyload=no \

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -17,10 +17,6 @@ patchAndMakeICU() {
   printf "ICU version: ${ICU_VERSION_MAJOR}\n"
   $SCRIPT_DIR/patch.sh icu
 
-  # use compiled .dat archive from Android Chromium
-  cp $TARGETDIR/icu/android/icudtl.dat $TARGETDIR/icu/source/data/in/icudt${ICU_VERSION_MAJOR}l.dat
-  rm $TARGETDIR/icu/source/data/translit/root_subset.txt $TARGETDIR/icu/source/data/translit/trnslocal.mk
-
   rm -rf $TARGETDIR/icu/host
   mkdir -p $TARGETDIR/icu/host
   cd $TARGETDIR/icu/host
@@ -32,6 +28,7 @@ patchAndMakeICU() {
     CFLAGS="-g2"
   fi
 
+  ICU_DATA_FILTER_FILE="${TARGETDIR}/icu/filters/android.json" \
   $TARGETDIR/icu/source/runConfigureICU Linux \
   --prefix=$PWD/prebuilts \
   CFLAGS="$CFLAGS" \


### PR DESCRIPTION
# Summary
    Upgrade ICU to Chromium M76 used version. Fixes #98 
    ICU version is 64.2

    https://chromium.googlesource.com/chromium/src/+/refs/tags/76.0.3809.87/DEPS#984
    https://chromium.googlesource.com/chromium/deps/icu/+/64e5d7d43a1ff205e3787ab6150bbc1a1837332b%5E%21/

    Some changes are for ICU 64 data buildtool changes.
    https://github.com/unicode-org/icu/blob/master/docs/userguide/icu_data/buildtool.md

## Test Plan

### What's required for testing (prerequisites)?
Use Intl version and verify the test case provided by @danilobuerger
Expected result should be:
```
var x = 1.2;
console.log(x.toLocaleString('de-US'));
console.log(x.toLocaleString('en-DE'));
> "1,2"
> "1,2"
```

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
