### PR TITLE
fix: move prefab headers inside JavaScriptCore folder

### DIFF
--- a/lib/jsc-android/build.gradle
+++ b/lib/jsc-android/build.gradle
@@ -11,6 +11,8 @@ def i18n = project.findProperty("i18n") ?: ""
 def signingKey = project.findProperty('signingKey')
 def signingPassword = project.findProperty('signingPassword')
 
+def prefabHeadersDir = "${buildDir}/prefab-headers"
+
 if (!distDir) throw new RuntimeException("expecting --project-prop distDir=??? but was empty")
 if (!jniLibsDir) throw new RuntimeException("expecting --project-prop jniLibsDir=??? but was empty")
 if (!version) throw new RuntimeException("expecting --project-prop version=??? but was empty")
@@ -56,7 +58,7 @@ android {
 
   prefab {
     jsc {
-      headers file(headersDir).absolutePath
+      headers file(prefabHeadersDir).absolutePath
     }
   }
 
@@ -72,7 +74,17 @@ project.group = "io.github.react-native-community"
 def artifactName = Boolean.valueOf(i18n) ? "jsc-android-intl" : "jsc-android"
 project.version = "${version}"
 
+tasks.register('preparePrefabHeaders', Copy) {
+  from("${headersDir}")
+  filesMatching('**/*.h') {
+    path = "JavaScriptCore/${it.name}"
+  }
+  into(file("${prefabHeadersDir}"))
+}
+
 afterEvaluate {
+  preBuild.dependsOn(preparePrefabHeaders)
+
   publishing {
     publications {
       release(MavenPublication) {


### PR DESCRIPTION
# Why

following up https://github.com/facebook/react-native/pull/47972#discussion_r1862446077

# How

move prefab headers into `JavaScriptCore/` directory, so that `#include <JavaScriptCore/JavaScript.h>` in JSCRuntime will not break. this also simulates how JavaScriptCore.framework works.

# Test Plan

ci passed